### PR TITLE
updated and tested password connect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pjlink",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Projector",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pjlink",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Projector",

--- a/pjlink.js
+++ b/pjlink.js
@@ -107,7 +107,7 @@ instance.prototype.init_tcp = function(cb) {
 			if (data.match(/^PJLINK ERRA/)) {
 				self.log('error', 'Authentication error. Password not accepted by projector');
 				self.commands.length = 0;
-				self.status(self.STATUS_ERROR, 'Authenticatione error');
+				self.status(self.STATUS_ERROR, 'Authentication error');
 				self.connected = false;
 				self.connecting = false;
 				self.socket.destroy();
@@ -225,14 +225,34 @@ instance.prototype.actions = function(system) {
 		'shutterOpen':    { label: 'Open Shutter' },
 		'shutterClose':   { label: 'Close Shutter' },
 		'freeze':         { label: 'Freeze Input' },
-		'unfreeze':       { label: 'Unfreeze Input' }
-
+		'unfreeze':       { label: 'Unfreeze Input' },
+		'inputToggle': {
+			label: 'Toggle Input',
+			options: [
+				{
+					type: 'dropdown',
+					label: 'Select input',
+					id: 'inputNum',
+					default: '31',
+					choices: [
+						{ id: '11', label: 'RGB1'},
+						{ id: '12', label: 'RGB2' },
+						{ id: '31', label: 'DVI-D'},
+						{ id: '32', label: 'HDMI' },
+						{ id: '33', label: 'Digital link' },
+						{ id: '34', label: 'SDI1' },
+						{ id: '35', label: 'SDI2' }
+					]
+				}
+			]
+		}
 	});
 };
 
 instance.prototype.action = function(action) {
 	var self = this;
 	var id = action.action;
+	var opt = action.options;
 	var cmd
 
 	switch (action.action){
@@ -259,6 +279,10 @@ instance.prototype.action = function(action) {
 
 		case 'unfreeze':
 			cmd = '%2frez 0';
+			break;
+
+		case 'inputToggle':
+			cmd = '%inpt ' + opt.inputNum;
 			break;
 
 	};

--- a/pjlink.js
+++ b/pjlink.js
@@ -31,9 +31,7 @@ instance.prototype.init = function() {
 	self.commands = [];
 
 	self.status(self.STATUS_UNKNOWN, 'Connecting');
-
-	// Initial connect to check status
-	self.send('%1POWR ?');
+	
 };
 
 instance.prototype.init_tcp = function(cb) {
@@ -120,7 +118,8 @@ instance.prototype.init_tcp = function(cb) {
 				var digest = match[1] + self.config.password;
 				var hasher = crypto.createHash('md5');
 				var hex = hasher.update(digest, 'utf-8').digest('hex');
-				self.socket.write(hex);
+				// transmit the authentication hash and a pjlink command
+				self.socket.write(hex + "%1powr ?\r");
 
 				// Shoot and forget, by protocol definition :/
 				if (typeof cb == 'function') {
@@ -282,7 +281,7 @@ instance.prototype.action = function(action) {
 			break;
 
 		case 'inputToggle':
-			cmd = '%inpt ' + opt.inputNum;
+			cmd = '%1inpt ' + opt.inputNum;
 			break;
 
 	};

--- a/pjlink.js
+++ b/pjlink.js
@@ -117,7 +117,7 @@ instance.prototype.init_tcp = function(cb) {
 
 			var match;
 			if (match = data.match(/^PJLINK 1 (\S+)/)) {
-				var digest = match[1] + ' ' + self.config.password;
+				var digest = match[1] + self.config.password;
 				var hasher = crypto.createHash('md5');
 				var hex = hasher.update(digest, 'utf-8').digest('hex');
 				self.socket.write(hex);


### PR DESCRIPTION
I continued testing @haakonnessjoen maybe fix code and realised that in order to successfully connect to a projector an initial command must be sent. I have successfully tested the code on Panasonic RZ970, RZ21K & RZ31K - authentication and input toggling is working correctly.

Should set the command sent with the authentication string to the actual request from companion rather than `%1powr ?` to minimise the packets sent.

deals with issues #4 #6 #7