### PR TITLE
Refactor protocol interaction with PJ

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"legacy": [
 		"pjlink"
 	],
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Projector",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"legacy": [
 		"pjlink"
 	],
-	"version": "1.1.2",
+	"version": "1.2.0",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Projector",
@@ -19,7 +19,8 @@
 	},
 	"author": "Per Roine <per.roine@gmail.com>",
 	"contributors": [
-		"Jamie McConchie"
+		"Jamie McConchie",
+		"John Knight, Jr <istnv@ayesti.com>"
 	],
 	"license": "MIT",
 	"homepage": "https://github.com/bitfocus/companion-module-generic-pjlink#readme",

--- a/pjlink.js
+++ b/pjlink.js
@@ -31,6 +31,11 @@ const CONFIG_FREEZE_STATE = [
 	{ id: '1', label: 'On' },
 ]
 
+const CONFIG_ON_OFF_TOGGLE = [
+	{ id: '0', label: 'Off' },
+	{ id: '1', label: 'On' },
+	{ id: '2', label: 'Toggle'}
+]
 const CONFIG_INPUTS = [
 	{ id: '11', label: 'RGB1' },
 	{ id: '12', label: 'RGB2' },
@@ -71,6 +76,7 @@ function instance(system, id, config) {
 
 	// super-constructor
 	instance_skel.apply(this, arguments)
+
 	self.projector = []
 	self.projector.lamps = []
 
@@ -88,6 +94,8 @@ function instance(system, id, config) {
 
 	return self
 }
+
+instance.DEVELOPER_forceStartupUpgradeScript = 0
 
 instance.GetUpgradeScripts = function () {
 	return [upgradescripts.upgrade_choices]
@@ -616,7 +624,7 @@ instance.prototype.actions = function (system) {
 					label: 'Select Power State',
 					id: 'opt',
 					default: '1',
-					choices: CONFIG_POWER_STATE.slice(0, 2),
+					choices: CONFIG_ON_OFF_TOGGLE
 				},
 			],
 		},
@@ -628,7 +636,7 @@ instance.prototype.actions = function (system) {
 					label: 'Select Mute State',
 					id: 'opt',
 					default: '30',
-					choices: CONFIG_MUTE_STATE,
+					choices: CONFIG_ON_OFF_TOGGLE
 				},
 			],
 		},
@@ -637,10 +645,10 @@ instance.prototype.actions = function (system) {
 			options: [
 				{
 					type: 'dropdown',
-					label: 'Select Mute State',
+					label: 'Select Freeze State',
 					id: 'opt',
 					default: '0',
-					choices: CONFIG_FREEZE_STATE,
+					choices: CONFIG_ON_OFF_TOGGLE
 				},
 			],
 		},
@@ -665,17 +673,24 @@ instance.prototype.action = function (action) {
 	var opt = action.options
 	var cmd
 
+	function setToggle(curVal, opt) {
+		return 2 == parseInt(opt) ? 1-parseInt(curVal) : parseInt(opt);
+	}
+
 	switch (action.action) {
 		case 'powerState':
-			cmd = '%1POWR ' + opt.opt
+			// don't send if warming/cooling
+			if ('01'.includes(self.projector.powerState)) {
+				cmd = '%1POWR ' + setToggle(self.projector.powerState == '1', opt.opt)
+			}
 			break
 
 		case 'muteState':
-			cmd = '%1AVMT ' + opt.opt
+			cmd = '%1AVMT ' + setToggle(self.projector.muteState,opt.opt)
 			break
 
 		case 'freezeState':
-			cmd = '%2FREZ ' + opt.opt
+			cmd = '%2FREZ ' + setToggle(self.projector.freezeState,opt.opt)
 			break
 
 		case 'inputToggle':

--- a/pjlink.js
+++ b/pjlink.js
@@ -1,4 +1,3 @@
-'use strict'
 var net = require('net')
 var instance_skel = require('../../instance_skel')
 var crypto = require('crypto')

--- a/pjlink.js
+++ b/pjlink.js
@@ -1,3 +1,4 @@
+'use strict'
 var net = require('net')
 var instance_skel = require('../../instance_skel')
 var crypto = require('crypto')
@@ -20,6 +21,12 @@ const CONFIG_ERROR_STATE = [
 	{ id: '2', label: 'Error' },
 ]
 
+const SHOW_ERROR_STATE = [
+	'No Error',
+	'Warning',
+	'Error'
+]
+
 const CONFIG_FREEZE_STATE = [
 	{ id: '0', label: 'Off' },
 	{ id: '1', label: 'On' },
@@ -36,6 +43,15 @@ const CONFIG_INPUTS = [
 	{ id: '52', label: 'LAN' },
 	{ id: '56', label: 'HDBaseT' },
 ]
+
+const CONFIG_INPUT_CLASS = {
+	'1': 'RGB',
+	'2': 'Video' ,
+	'3': 'Digital' ,
+	'4': 'Storage' ,
+	'5': 'Network' ,
+	'6': 'Internal',
+}
 
 const CONFIG_MUTE_STATE = [
 	{ id: '11', label: 'Video mute On' },
@@ -93,13 +109,60 @@ instance.prototype.init = function () {
 	debug = self.debug
 	log = self.log
 
+	self.DebugLevel = 0
+
+
 	self.commands = []
 	//self.projector.class = '1'
 
-	self.status(self.STATUS_UNKNOWN, 'Connecting')
+	self.status(self.STATUS_WARNING, 'Connecting')
 	self.init_tcp()
 	self.init_variables()
 	self.init_feedbacks()
+}
+
+instance.prototype.check_auth = function(data, cb) {
+	var self = this
+	var match
+
+	if ('PJLINK ERRA' == data) {
+		debug('Password not accepted')
+		self.log('error', 'Authentication error. Password not accepted by projector')
+		self.commands.length = 0
+		self.status(self.STATUS_ERROR, 'Authentication error')
+		self.connected = false
+		self.authOK = false
+		self.passwordstring = ''
+		self.socket.destroy()
+		delete self.socket
+		return
+	} else if ('PJLINK 0' == data) {
+		debug('Projector does not need password')
+		self.passwordstring = ''
+		self.authOK = true
+	} else if (match = data.match(/^PJLINK 1 (\S+)/)) {
+		var digest = match[1] + self.config.password
+		var hasher = crypto.createHash('md5')
+		self.passwordstring = hasher.update(digest, 'utf-8').digest('hex')
+		self.authOK = true
+	}
+	if (self.lastStatus != self.STATUS_OK + ';Auth') {
+		self.status(self.STATUS_OK, 'Auth OK')
+		self.lastStatus = self.STATUS_OK + ';Auth'
+	}
+
+	// send first command with (or without) auth password
+	self.lastCmd = '%1POWR ?'
+	self.socket?.write(self.passwordstring + self.lastCmd + '\r')
+
+	self.getProjectorDetails()
+	self.pollTime = self.config.pollTime ? self.config.pollTime * 1000 : 10000
+	self.poll_interval = setInterval(self.poll.bind(self), self.pollTime) //ms for poll
+	self.poll()
+
+	if (typeof cb == 'function') {
+		cb()
+	}
 }
 
 instance.prototype.init_tcp = function (cb) {
@@ -107,6 +170,10 @@ instance.prototype.init_tcp = function (cb) {
 	var receivebuffer = ''
 	self.passwordstring = ''
 	var match
+	var cmd
+	var err
+	var resp
+	var projClass
 
 	if (self.socketTimer) {
 		clearInterval(self.socketTimer)
@@ -115,6 +182,7 @@ instance.prototype.init_tcp = function (cb) {
 
 	if (self.poll_interval) {
 		clearInterval(self.poll_interval)
+		delete self.poll_interval
 	}
 
 	if (self.socket !== undefined) {
@@ -123,40 +191,65 @@ instance.prototype.init_tcp = function (cb) {
 	}
 
 	if (self.config.host) {
-		self.connecting = true
+		self.authOK = true
 		self.commands = []
 
 		self.socket = new net.Socket()
 		self.socket.setNoDelay(true)
 
 		self.socket.on('error', function (err) {
-			debug('Network error', err)
-			self.status(self.STATE_ERROR, err)
-			self.log('error', 'Network error: ' + err.message)
+			debug('Network ', err)
+			if (self.lastStatus != self.STATUS_ERROR + ';' + err.name) {
+				self.status(self.STATUS_ERROR, 'Network ' + err.message)
+				self.lastStatus = self.STATUS_ERROR + ';' + err.name
+				self.log('error', 'Network ' + err.message)
+			}
 			self.connected = false
-			self.connecting = false
+			self.authOK = false
 			delete self.socket
+			// set timer to retry connection in 30 secs
+			if (self.socketTimer) {
+				clearInterval(self.socketTimer)
+				delete self.socketTimer
+			}
+			self.socketTimer = setInterval(function() {
+					self.status(self.STATUS_ERROR,'Retrying connection')
+					self.init_tcp()
+				}, 30000)
 		})
 
 		self.socket.on('connect', function () {
 			receivebuffer = ''
 			self.connect_time = Date.now()
 
-			if (self.currentStatus != self.STATUS_OK) {
+			if (self.lastStatus != self.STATUS_OK) {
 				self.status(self.STATUS_OK, 'Connected')
+				self.log('info','Connected')
 				debug('Connected to projector')
+				self.lastStatus = self.STATUS_OK
 			}
-			self.getProjectorDetails()
-			self.pollTime = self.config.pollTime ? self.config.pollTime * 1000 : 10000
-			self.poll_interval = setInterval(self.poll.bind(self), self.pollTime) //ms for poll
-			self.poll()
-
 			self.connected = true
+			self.authOK = false
+
 		})
 
 		self.socket.on('end', function () {
 			self.connected = false
-			self.connecting = false
+			self.authOK = false
+			if (self.lastStatus != self.STATUS_ERROR + ';Disc') {
+				self.log('error','Projector Disconnected')
+				self.status(self.STATUS_ERROR, 'Disconnected')
+				self.lastStatus = self.STATUS_ERROR + ';Disc'
+			}
+			// set timer to retry connection in 30 secs
+			if (self.socketTimer) {
+				clearInterval(self.socketTimer)
+				delete self.socketTimer
+			}
+			self.socketTimer = setInterval(function() {
+				self.status(self.STATUS_ERROR,'Retrying connection')
+				self.init_tcp()
+			}, 30000)
 			debug('Disconnected')
 		})
 
@@ -167,255 +260,272 @@ instance.prototype.init_tcp = function (cb) {
 				offset = 0
 			receivebuffer += chunk
 			while ((i = receivebuffer.indexOf('\r', offset)) !== -1) {
-				line = receivebuffer.substr(offset, i - offset)
+				line = receivebuffer.slice(offset, i )
 				offset = i + 1
-				self.socket.emit('receiveline', line.toString())
+				self.socket?.emit('receiveline', line.toString())
 			}
-			receivebuffer = receivebuffer.substr(offset)
+			receivebuffer = receivebuffer.slice(offset)
 		})
 
 		self.socket.on('receiveline', function (data) {
+
 			self.connect_time = Date.now()
 
-			debug('PJLINK: < ', data)
+			if (self.DebugLevel>1) {
+				debug('PJLINK: < ' , data)
+			}
 
-			if (data.match(/^PJLINK ERRA/)) {
-				debug('Password not accepted')
-				self.log('error', 'Authentication error. Password not accepted by projector')
-				self.commands.length = 0
-				self.status(self.STATUS_ERROR, 'Authentication error')
-				self.connected = false
-				self.connecting = false
-				self.socket.destroy()
-				delete self.socket
+			// auth password setup
+			if (data.match(/^PJLINK*/)) {
+				self.check_auth(data,cb)
 				return
 			}
 
-			if (data.match(/^PJLINK 0/)) {
-				debug('Projector does not need password')
-				self.passwordstring = ''
-
-				// no auth
-				if (typeof cb == 'function') {
-					cb()
-				}
-			}
-
 			if ((match = data.match(/^(%(\d).+)=ERR(\d)/))) {
+				var errorText = 'Unknown error'
+				var newState = 'warn'
+				var newStatus = self.STATUS_WARNING
 				cmd = match[1]
 				projClass = match[2]
 				err = match[3]
 
 				switch (err) {
 					case '1':
-						{
-							errorText =
-								projClass === self.projector.class
-									? 'Undefined command: ' + cmd
-									: 'Command for different Project Class: ' + cmd
-							self.log('error', errorText)
-							debug('PJLINK ERROR: ', errorText)
-						}
+						errorText =
+							projClass === self.projector.class
+								? 'Undefined command: ' + cmd
+								: 'Command for different Protocol Class: ' + cmd
 						break
 					case '2':
-						{
-							self.log('error', 'Projector reported '+ cmd + ': Out of parameter')
-							debug('PJLINK ERROR: ', cmd + ' Out of parameter')
+						errorText = 'Projector reported ' + cmd
+						if (cmd.slice(2) == 'INPT') {
+							errorText += ': No such input'
+						} else {
+							errorText += ': Out of parameter'
 						}
 						break
 					case '3':
-						{
-							self.log('error', 'Projector reported Unavailable time. Command was ' + cmd)
-							debug('PJLINK ERROR: Unavailable time ' + cmd)
+						if (self.projector.powerState == '0') {
+							errorText = `Command '${cmd}' unavailable. Projector in standby.`
+						} else {
+							errorText = 'Projector Unavailable time. Command was ' + cmd
 						}
 						break
 					case '4':
-						{
-							self.log('error', 'Projector/Display failure')
-							debug('PJLINK ERROR: Projector/Display failure')
-						}
+						errorText = 'Projector/Display failure'
+						newState = 'error'
+						newStatus = self.STATUS_ERROR
 						break
 				}
-				return
-			}
-
-			if ((match = data.match(/^%1CLSS=(\d)/))) {
-				self.projector.class = match[1]
-				self.setVariable('projectorClass', self.projector.class)
-				self.socket.emit('projectorClass')
-				//self.checkFeedbacks('projectorClass')
-			}
-
-			if ((match = data.match(/^%1NAME=(.+)/))) {
-				self.projector.name = match[1]
-				self.setVariable('projectorName', self.projector.name)
-			}
-
-			if ((match = data.match(/^%1INF1=(.+)/))) {
-				self.projector.make = match[1]
-				self.setVariable('projectorMake', self.projector.make)
-			}
-
-			if ((match = data.match(/^%1INF2=(.+)/))) {
-				self.projector.model = match[1]
-				self.setVariable('projectorModel', self.projector.model)
-			}
-
-			if ((match = data.match(/^%1INFO=(.+)/))) {
-				self.projector.other = match[1]
-				self.setVariable('projectorOther', self.projector.other)
-			}
-
-			if ((match = data.match(/^%2RLMP=(.+)/))) {
-				self.projector.lampReplacement = match[1]
-				self.setVariable('lampReplacement', self.projector.lampReplacement)
-			}
-
-			if ((match = data.match(/^%1INST=(.+)/))) {
-				self.projector.availInputs = match[1].split(' ')
-			}
-
-			if ((match = data.match(/^%2INST=(.+)/))) {
-				self.projector.availInputs = match[1].split(' ')
-
-				self.getInputName(self.projector.availInputs)
-			}
-
-			if ((match = data.match(/^%2INNM=(.+)/))) {
-				if (!(match[1] === 'ERR1' || match[1] === 'ERR2' || match[1] === 'ERR3')) {
-					idx = self.projector.inputNames.findIndex((o) => o.label === null)
-					self.projector.inputNames[idx].label = match[1]
+				if (self.lastStatus != newStatus + ';' + err) {
+					self.log(newState, errorText)
+					self.status(newStatus, errorText)
+					self.lastStatus = newStatus + ';' + err
 				}
-			}
+				debug('PJLINK ERROR: ', errorText)
+				cmd = data.slice(0,6)
+			} else {
+				cmd = data.slice(0,6)
+				resp = data.slice(7)
 
-			if ((match = data.match(/^%1POWR=(\d)/))) {
-				self.projector.powerState = match[1]
-				self.setVariable('powerState', CONFIG_POWER_STATE.find((o) => o.id == self.projector.powerState)?.label)
-				self.checkFeedbacks('powerState')
-			}
-
-			if ((match = data.match(/^%\dINPT=(\d+)/))) {
-				self.projector.inputNum = match[1]
-				self.setVariable(
-					'projectorInput',
-					self.projector.inputNames.find((o) => o.id == self.projector.inputNum)?.label
-				)
-				self.checkFeedbacks('projectorInput')
-			}
-
-			if ((match = data.match(/^%1LAMP=(.+)/))) {
-				var response = match[1].match(/(\d+.\d)/g)
-				response.forEach((element, index) => {
-					hours = element.split(' ')[0]
-					on = element.split(' ')[1] === '1' ? 'On' : 'Off'
-					self.projector.lamps[index] = { lamp: index + 1, hours: hours, on: on }
-				})
-				self.projector.lamps.forEach((element, index) => {
-					self.setVariable('lamp' + [index + 1] + 'Hrs', element.hours)
-					self.setVariable('lamp' + [index + 1] + 'On', element.on)
-				})
-				self.checkFeedbacks('lampHour')
-			}
-
-			if ((match = data.match(/^%2IRES=(\d+)x(\d+)/))) {
-				self.projector.inputHorzRes = match[1]
-				self.projector.inputVertRes = match[2]
-				self.setVariable('inputHorzRes', self.projector.inputHorzRes)
-				self.setVariable('inputVertRes', self.projector.inputVertRes)
-			}
-
-			if ((match = data.match(/^%2RRES=(\d+)x(\d+)/))) {
-				self.projector.recHorzRes = match[1]
-				self.projector.recVertRes = match[2]
-				self.setVariable('recHorzRes', self.projector.recHorzRes)
-				self.setVariable('recVertRes', self.projector.recVertRes)
-			}
-
-			if ((match = data.match(/^%1ERST=(\d)(\d)(\d)(\d)(\d)(\d)/))) {
-				self.projector.errorFan = match[1]
-				self.projector.errorLamp = match[2]
-				self.projector.errorTemp = match[3]
-				self.projector.errorCover = match[4]
-				self.projector.errorFilter = match[5]
-				self.projector.errorOther = match[6]
-				self.setVariable('errorFan', CONFIG_ERROR_STATE.find((o) => o.id == self.projector.errorFan)?.label)
-				self.setVariable('errorLamp', CONFIG_ERROR_STATE.find((o) => o.id == self.projector.errorLamp)?.label)
-				self.setVariable('errorTemp', CONFIG_ERROR_STATE.find((o) => o.id == self.projector.errorTemp)?.label)
-				self.setVariable('errorCover', CONFIG_ERROR_STATE.find((o) => o.id == self.projector.errorCover)?.label)
-				self.setVariable('errorFilter', CONFIG_ERROR_STATE.find((o) => o.id == self.projector.errorFilter)?.label)
-				self.setVariable('errorOther', CONFIG_ERROR_STATE.find((o) => o.id == self.projector.errorOther)?.label)
-				self.checkFeedbacks('errors')
-			}
-
-			if ((match = data.match(/^%1AVMT=(\d+)/))) {
-				self.projector.muteState = match[1]
-				self.setVariable('muteState', CONFIG_MUTE_STATE.find((o) => o.id == self.projector.muteState)?.label)
-				self.checkFeedbacks('muteState')
-			}
-
-			if ((match = data.match(/^%2FREZ=(\d+)/))) {
-				self.projector.freezeState = match[1]
-				self.setVariable('freezeState', CONFIG_FREEZE_STATE.find((o) => o.id == self.projector.freezeState)?.label)
-				self.checkFeedbacks('freezeState')
-			}
-
-			if ((match = data.match(/^%2SNUM=(.+)/))) {
-				self.projector.serialNumber = match[1]
-				self.setVariable('serialNumber', self.projector.serialNumber)
-			}
-
-			if ((match = data.match(/^%2SVER=(.+)/))) {
-				self.projector.softwareVer = match[1]
-				self.setVariable('softwareVer', self.projector.softwareVer)
-			}
-
-			if ((match = data.match(/^%2FILT=(.+)/))) {
-				self.projector.filterUsageTime = match[1]
-				self.setVariable('filterUsageTime', self.projector.filterUsageTime)
-			}
-
-			if ((match = data.match(/^PJLINK 1 (\S+)/))) {
-				var digest = match[1] + self.config.password
-				var hasher = crypto.createHash('md5')
-				var hex = hasher.update(digest, 'utf-8').digest('hex')
-				// transmit the authentication hash and a pjlink command
-				self.socket.write(hex + '%1POWR ?\r')
-
-				// Shoot and forget, by protocol definition :/
-				if (typeof cb == 'function') {
-					cb()
+				switch (cmd) {
+					case '%1CLSS':
+						self.projector.class = resp
+						self.setVariable('projectorClass', resp)
+						self.socket.emit('projectorClass')
+						break
+					case '%1NAME':
+						self.projector.name = resp
+						self.setVariable('projectorName', resp)
+						break
+					case '%1INF1':
+						self.projector.make = resp
+						self.setVariable('projectorMake', resp)
+						break
+					case '%1INF2':
+						self.projector.model = resp
+						self.setVariable('projectorModel', resp)
+						break
+					case '%1INFO':
+						self.projector.other = resp
+						self.setVariable('projectorOther', resp)
+						break
+					case '%2RLMP':
+						self.projector.lampReplacement = resp
+						self.setVariable('lampReplacement', resp)
+						break
+					case '%2RFIL':
+						self.projector.filterRepacement = resp
+						self.setVariable('filterReplacement',resp)
+						break
+					case '%1INST':
+					case '%2INST':
+						self.projector.availInputs = resp.split(' ')
+						if (cmd.slice(1,2) == '2') {
+							self.getInputName(self.projector.availInputs)
+						}
+						break
+					case '%2INNM':
+						switch (resp) {
+							case 'ERR1':
+							case 'ERR2':
+							case 'ERR3':
+								break
+							default:
+								var idx = self.projector.inputNames.findIndex((o) => o.label === null)
+								self.projector.inputNames[idx].label = resp
+								self.haveNames += 1
+								self.updateActions = self.projector.inputNames.length == self.haveNames
+						}
+						break
+					case '%1POWR':
+						self.projector.powerState = resp
+						self.setVariable('powerState',CONFIG_POWER_STATE.find((o) => o.id == resp)?.label)
+						self.checkFeedbacks('powerState')
+						// reset warining (if any)
+						if (resp == '1' && self.lastStatus != self.STATUS_OK + ';Auth') {
+							self.status(self.STATUS_OK, 'Auth OK')
+							self.lastStatus = self.STATUS_OK + ';Auth'
+						}
+						break
+					case '%1INPT':
+					case '%2INPT':
+						// PJ returns 'OK' when input is switched
+						if ('OK' == resp) {
+							return
+						}
+						var iName = self.projector.inputNames.find((o) => o.id == resp)?.label
+						if (!iName) {
+							iName = CONFIG_INPUT_CLASS[resp[0]] + resp[1]
+							self.projector.inputNames.push({id: resp, label: iName })
+						}
+						if (resp != self.projector.inputNum) {
+							self.projector.inputNum = resp
+							self.setVariable('projectorInput',iName)
+							self.checkFeedbacks('projectorInput')
+							// only check input res when input changes
+							if (cmd.slice(1,2) == '2') {
+								self.send('%2IRES ?')
+							}
+						}
+						break
+					case '%1LAMP':
+						var stat = resp.split(' ')
+						for (let i = 0; i < stat.length; i += 2) {
+							var thisLamp = Math.floor(i / 2)
+							var lampHours = stat[i]
+							var onState = (stat[i+1] == '1' ? 'On': 'Off')
+							self.projector.lamps[thisLamp] = {lamp: thisLamp, hours: lampHours, on: onState}
+							self.setVariable('lamp' + (thisLamp + 1) + 'Hrs', lampHours)
+							self.setVariable('lamp' + (thisLamp + 1) + 'On', onState)
+						}
+						// fill table for unused lamps
+						for (let i = stat.length; i < 16; i += 2) {
+							var thisLamp = Math.floor(i / 2)
+							self.projector.lamps[thisLamp] = { lamp: thisLamp, hours: 0, on: 'Off' }
+							self.setVariable('lamp' + (thisLamp + 1) + 'Hrs', 0)
+							self.setVariable('lamp' + (thisLamp + 1) + 'On', 'Off')
+						}
+						self.checkFeedbacks('lampHour')
+						break
+					case '%2IRES':
+						var res = resp.split('x')
+						self.projector.inputHorzRes = res[0]
+						self.projector.inputVertRes = res[1]
+						self.setVariable('inputHorzRes', res[0])
+						self.setVariable('inputVertRes', res[1])
+						break
+					case '%2RRES':
+						var res = resp.split('x')
+						self.projector.recHorzRes = res[0]
+						self.projector.recVertRes = res[1]
+						self.setVariable('recHorzRes', res[0])
+						self.setVariable('recVertRes', res[1])
+						break
+					case '%1ERST':
+						var errs = resp.split('')
+						self.projector.errorFan = errs[0]
+						self.projector.errorLamp = errs[1]
+						self.projector.errorTemp = errs[2]
+						self.projector.errorCover = errs[3]
+						self.projector.errorFilter = errs[4]
+						self.projector.errorOther = errs[5]
+						self.setVariable('errorFan', SHOW_ERROR_STATE[errs[0]])
+						self.setVariable('errorLamp', SHOW_ERROR_STATE[errs[1]])
+						self.setVariable('errorTemp', SHOW_ERROR_STATE[errs[2]])
+						self.setVariable('errorCover', SHOW_ERROR_STATE[errs[3]])
+						self.setVariable('errorFilter', SHOW_ERROR_STATE[errs[4]])
+						self.setVariable('errorOther', SHOW_ERROR_STATE[errs[5]])
+						self.checkFeedbacks('errors')
+						break
+					case '%1AVMT':
+						self.projector.muteState = resp
+						self.setVariable('muteState', CONFIG_MUTE_STATE.find((o) => o.id == resp)?.label)
+						self.checkFeedbacks('muteState')
+						break
+					case '%2FREZ':
+						self.projector.freezeState = resp
+						self.setVariable('freezeState', CONFIG_FREEZE_STATE.find((o) => o.id == resp)?.label)
+						self.checkFeedbacks('freezeState')
+						break
+					case '%2SNUM':
+						self.projector.serialNumber = resp
+						self.setVariable('serialNumber', resp)
+						break
+					case '%2SVER':
+						self.projector.softwareVer = resp
+						self.setVariable('softwareVer', resp)
+						break
+					case '%2FILT':
+						self.projector.filterUsageTime = resp
+						self.setVariable('filterUsageTime', resp)
+						break
 				}
 			}
 
 			if (self.commands.length) {
-				var cmd = self.commands.shift()
-
-				self.socket.write(self.passwordstring + cmd + '\r')
+				if (self.lastCmd != cmd) {
+					debug (`Response mismatch, expected ${self.lastCmd}`)
+				}
+				var nextCmd = self.commands.shift()
+				if (self.DebugLevel >= 1) {
+					debug('PJLINK: > ' + nextCmd)
+				}
+				self.lastCmd = nextCmd.slice(0,6)
+				self.socket.write(self.passwordstring + nextCmd + '\r')
 			} else {
-				clearInterval(self.socketTimer)
+				if (self.socketTimer) {
+					clearInterval(self.socketTimer)
+					delete self.socketTimer
+				}
 
 				self.socketTimer = setInterval(function () {
 					if (self.commands.length > 0) {
 						var cmd = self.commands.shift()
 						self.connect_time = Date.now()
+						self.lastCmd = cmd.slice(0,6)
 						self.socket.write(self.passwordstring + cmd + '\r')
 						clearInterval(self.socketTimer)
 						delete self.socketTimer
 					}
 
-					if (Date.now() - self.connect_time > 4000) {
+					// istnv: an old version of the documentation stated 4 seconds.
+					//		Reading through version 1.04 and version 2.00,
+					//		idle time is 30 seconds
+
+					if (Date.now() - self.connect_time > 30000) {
+
+						if (self.socketTimer) {
+							clearInterval(self.socketTimer)
+							delete self.socketTimer
+						}
 						if (self.socket !== undefined && self.socket.destroy !== undefined) {
 							self.socket.destroy()
 						}
 
 						delete self.socket
 						self.connected = false
-						self.connecting = false
-
-						if (self.socketTimer) {
-							clearInterval(self.socketTimer)
-							delete self.socketTimer
-						}
+						self.authOK = false
 
 						debug('disconnecting per protocol defintion :(')
 					}
@@ -424,20 +534,29 @@ instance.prototype.init_tcp = function (cb) {
 		})
 
 		self.socket.connect(4352, self.config.host)
+
 	}
+
 }
 
 instance.prototype.send = function (cmd) {
 	var self = this
 
-	debug('PJLINK: > ', cmd)
-	debug('self.commands is', self.commands)
+	if (self.DebugLevel >= 1) {
+		debug('PJLINK(send): > ', cmd)
+	}
+	if (self.DebugLevel >= 2) {
+		debug('self.commands is', self.commands)
+	}
 
-	if (self.connecting) {
+	if (!self.authOK) {
 		self.commands.push(cmd)
+	} else if (self.connected) {
+		self.socket.write(self.passwordstring + cmd + '\r')
 	} else {
-		self.init_tcp(function () {
+			self.init_tcp(function () {
 			self.connect_time = Date.now()
+			self.lastCmd = cmd.slice(0,6)
 
 			self.socket.write(self.passwordstring + cmd + '\r')
 		})
@@ -481,6 +600,7 @@ instance.prototype.destroy = function () {
 
 	if (self.poll_interval !== undefined) {
 		clearInterval(self.poll_interval)
+		delete self.poll_interval
 	}
 	debug('destroy', self.id)
 }
@@ -565,9 +685,20 @@ instance.prototype.action = function (action) {
 	}
 
 	if (cmd !== undefined) {
-		debug('sending ', cmd, 'to', self.config.host)
+		if (self.DebugLevel >= 1) {
+			debug('sending ', cmd, 'to', self.config.host)
+		}
+
+		// reset warining (if any)
+		if (self.lastStatus != self.STATUS_OK + ';Auth') {
+			self.status(self.STATUS_OK, 'Auth OK')
+			self.lastStatus = self.STATUS_OK + ';Auth'
+		}
 
 		self.send(cmd)
+		// follow up with a status update
+
+		self.send(cmd.slice(0,7) + '?')
 	}
 
 	// debug('action():', action);
@@ -1001,22 +1132,23 @@ instance.prototype.getProjectorDetails = function () {
 	//Query Projector Class
 	self.send('%1CLSS ?')
 
-	//Query Projector Name
-	self.send('%1NAME ?')
-	//Query Projector Manufacturer
-	self.send('%1INF1 ?')
-	//Query Projector Product Name
-	self.send('%1INF2 ?')
-	//Query Projector Product Name
-	self.send('%1INFO ?')
-	//Query Input List
-	self.send('%1INST ?')
-
 	//Projector Class dependant initial queries
 	self.socket.on('projectorClass', function () {
+
+		//any class
+
+		//Query Projector Name
+		self.send('%1NAME ?')
+		//Query Projector Manufacturer
+		self.send('%1INF1 ?')
+		//Query Projector Product Name
+		self.send('%1INF2 ?')
+		//Query Projector Product Name
+		self.send('%1INFO ?')
+
+		self.send(`%${self.projector.class}INST ?`)
+
 		if (self.projector.class === '2') {
-			//Query Input List
-			self.send('%2INST ?')
 			//Query Serial Number
 			self.send('%2SNUM ?')
 			//Query Software Version
@@ -1025,44 +1157,72 @@ instance.prototype.getProjectorDetails = function () {
 			self.send('%2RLMP ?')
 			//Query Filter Replacement
 			self.send('%2RFIL ?')
+			//Query Recommended Resolution
+			self.send('%2RRES ?')
 		}
+
 	})
 }
 
 instance.prototype.poll = function () {
 	var self = this
+	var checkHours = false
 
+	// re-connect?
+	if (!self.connected) {
+		self.init_tcp()
+		return
+	}
+	// wait for class response before sending status requests
+	if (self.projector.class === undefined)  {
+		return
+	}
+
+	// first time or every 10 minutes
+	if (self.lastHours===undefined || Date.now() - self.lastHours > 600000) {
+		checkHours = true
+		self.lastHours = Date.now()
+	}
+
+	// class 2 got full list of input names from PJ
+	if (self.updateActions) {
+		self.actions() // reload actions
+	}
 	//Query Power
 	self.send('%1POWR ?')
-	//Query Lamp
-	self.send('%1LAMP ?')
 	//Query Error Status
 	self.send('%1ERST ?')
-	//Query Mute Status
-	self.send('%1AVMT ?')
+	//Query Lamp
+	// -- I was going to add this to the 10 minute check
+	// -- but the response includes the lamp on status
+	self.send('%1LAMP ?')
 
-	//Query Input
-	self.projector.class === '2' ? self.send('%2INPT ?') : self.send('%1INPT ?')
+	//Query Mute Status and input (only valid if PJ is on)
+	if (self.projector.powerState == '1') {
+		self.send('%1AVMT ?')
+		self.send(`%${self.projector.class}INPT ?`)
+	}
 
 	//Class 2 Queries
 	if (self.projector.class === '2') {
-		//Query Input Resolution
-		self.send('%2IRES ?')
-		//Query Recommended Resolution
-		self.send('%2RRES ?')
-		//Query Freeze Status
-		self.send('%2FREZ ?')
+		//Query Freeze Status (only if PJ is on)
+		if (self.projector.powerState == '1') {
+			self.send('%2FREZ ?')
+		}
 		//Query Filter Usage
-		self.send('%2FILT ?')
+		if (checkHours) {
+			self.send('%2FILT ?')
+		}
 	}
 
-	self.actions() // reload actions
-	debug('self.projector is', self.projector)
+	// debug('self.projector is', self.projector)
 }
 
 instance.prototype.getInputName = function (inputs) {
 	var self = this
+	// class 2 names the inputs, so start with an empty list
 	self.projector.inputNames = []
+	self.haveNames = 0
 	for (const element of inputs) {
 		self.projector.inputNames.push({ id: element, label: null })
 		self.send('%2INNM ?' + element)


### PR DESCRIPTION
Many fixes/updates. Should correct #32.

- Located and removed a couple of stray timers
- Optimize/consolidate long `if (match` to single `switch / case` 
- De-duplicate some logic into separate functions
- Handle auth errors gracefully
- Recover from PJ errors
- Reduce log clutter from status updates
- Reduce net traffic:
-- request static projector information (model/serial no) only once
-- request long-term information (filter hours) every 10 minutes
-- respect protocol Class on polling to reduce `unknown` command errors
-- ignore certain actions when projector is not in 'On' state
- added Toggle to Mute/Freeze/Power
- typo on freeze action

Tested for many hours against the JBMIA emulator and a custom emulator.
