### PR TITLE
Generate inputs from projector response on Class 1 projectors; Check for Laser PJ

### DIFF
--- a/HELP.md
+++ b/HELP.md
@@ -6,6 +6,14 @@
 - AV Mute Projector
 - Freeze / Unfreeze Input
 - Change Input (Dynamic Input Names from Projector)
+- **Note:** Class 2 projectors provide actual input names
+<br>Class 1 Projectors will create generic names based on the input type:
+  - 1: RGB (analog)
+  - 2: Video (analog)
+  - 3: Digital (SDI, DVI, HDMI)
+  - 4: Storage (USB, SD Card)
+  - 5: Network (HD-BaseT, NDI)
+  - 6: Internal (Flash memory Logo or still)
 
 **Available variables for PJLink**
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"legacy": [
 		"pjlink"
 	],
-	"version": "1.2.4",
+	"version": "1.3.0",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Projector",


### PR DESCRIPTION
**Issue #44 and #46**
BUG: Class 1 and 2 projectors provide actual input IDs. Only class 2 provides the internal name.
The module was using a generic list of inputs that did not always correspond to the projector.

Updated to use the actual input list as reported by the projector to generate the input list.
NOTE: These are still generic names since the projector does not provide the actual names (Digital-1 may actually be labeled HDMI on the projector)

**Issue #45**
BUG: The newer Laser projectors do not provide lamp hours, and return an error that means 'No lamp here' when queried. 
Updated to catch this error and disable the lamp life feedback query.

Minor syntax cleanup
Version bump
Doc update to clarify input name limitations on Class 1 projectors