### PR TITLE
Ignore case in projector responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generic-pjlink",
-	"version": "2.0.1",
+	"version": "2.1.0",
 	"main": "pjlink.js",
 	"type": "module",
 	"scripts": {


### PR DESCRIPTION
The pj-link protocol spec is not clear about command/response letter case.
Responses are not always consistent (upper case) on some projector models: #59 
This update removes case sensitive comparison for commands and responses.

