### PR TITLE
Use equivalent vs strict on feedbacks

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -48,3 +48,7 @@
 - Mute Status
 - Power Status
 - Projector Input
+
+--------
+Contributions for development of this open source module are always welcome
+https://github.com/sponsors/istnv

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generic-pjlink",
-	"version": "2.1.2",
+	"version": "2.1.3",
 	"main": "pjlink.js",
 	"type": "module",
 	"scripts": {

--- a/pjlink.js
+++ b/pjlink.js
@@ -6,7 +6,7 @@ import * as CONFIG from './choices.js'
 import { UpgradeScripts } from './upgrades.js'
 
 function ar2obj(a) {
-	return a.map((e, i) => ({ id: i, label: e }))
+	return a.map((e, i) => ({ id: `${i}`, label: e }))
 }
 
 class PJInstance extends InstanceBase {
@@ -996,7 +996,7 @@ class PJInstance extends InstanceBase {
 					},
 				],
 				callback: (feedback, context) => {
-					return this.projector[feedback.options.error] === feedback.options.errorState
+					return this.projector[feedback.options.error] == feedback.options.errorState
 				},
 			},
 			freezeState: {
@@ -1017,7 +1017,7 @@ class PJInstance extends InstanceBase {
 					},
 				],
 				callback: (feedback, context) => {
-					return this.projector.freezeState === feedback.options.freezeState
+					return this.projector.freezeState == feedback.options.freezeState
 				},
 			},
 			lampHour: {
@@ -1108,7 +1108,7 @@ class PJInstance extends InstanceBase {
 					},
 				],
 				callback: (feedback, context) => {
-					return self.projector.inputNum === feedback.options.inputNum
+					return self.projector.inputNum == feedback.options.inputNum
 				},
 			},
 			powerState: {


### PR DESCRIPTION
Feedback choices do not seem to be consistently numbers vs characters. 
Reducing comparison to equivalent instead of strict overcomes this mismatch.
Issue #61 