### PR TITLE
Allow configuration when passcode is wrong

### DIFF
--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -3,7 +3,7 @@
 	"name": "generic-pjlink",
 	"shortname": "pjlink",
 	"description": "PJ-Link plugin for Companion",
-	"version": "2.0.1",
+	"version": "0.0.0",
 	"license": "MIT",
 	"repository": "git+https://github.com/bitfocus/companion-module-generic-pjlink.git",
 	"bugs": "https://github.com/bitfocus/companion-module-generic-pjlink/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generic-pjlink",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"main": "pjlink.js",
 	"type": "module",
 	"scripts": {

--- a/pjlink.js
+++ b/pjlink.js
@@ -598,7 +598,7 @@ class PJInstance extends InstanceBase {
 
 		if (this.badPassword) {
 			return
-		} else if (!this.authOK || this.badPassword) {
+		} else if (!this.authOK) {
 			sent = false
 		} else if (this.pjConnected) {
 			try {


### PR DESCRIPTION
Changing the passcode for a projector resulted in a retry loop.
This prevented the configuration tab from being displayed so the passcode could be corrected.
Fixes #79 