### PR TITLE
adding regex patten that match ipaddress and hostname

### DIFF
--- a/pjlink.js
+++ b/pjlink.js
@@ -626,9 +626,9 @@ class PJInstance extends InstanceBase {
 			{
 				type: 'textinput',
 				id: 'host',
-				label: 'Target IP',
+				label: 'Target IP or Hostname',
 				width: 6,
-				regex: Regex.IP,
+				regex: /^[a-zA-Z0-9.-]+$/,
 			},
 			{
 				type: 'textinput',


### PR DESCRIPTION
## Summary
 hostnames in addition to IP addresses for the PJLink connection configuration.

## Changes
- Updated the host field validation regex from `Regex.IP` to `/^[a-zA-Z0-9.-]+$/`
- Changed field label from "Target IP" to "Target IP or Hostname" for clarity
- Maintains backward compatibility with existing IP address configurations

## Benefits
- **Flexibility**: Users can now use hostnames 
## Technical Details
- The regex pattern `/^[a-zA-Z0-9.-]+$/` accepts:
  - Letters (a-z, A-Z)
  - Numbers (0-9)
  - Dots (.) for domain separators
  - Hyphens (-) for subdomain separators
- TCPHelper already supports hostname resolution natively
- No changes needed to the actual connection logic

