### PR TITLE
Fix/update feedback dropdown list

### DIFF
--- a/pjlink.js
+++ b/pjlink.js
@@ -1242,6 +1242,7 @@ class PJInstance extends InstanceBase {
 		// got full list of input names from PJ, update action dropdown
 		if (this.updateActions) {
 			this.buildActions() // reload actions
+			this.init_feedbacks() // reload feedbacks
 			this.updateActions = false // only need once
 		}
 		// resend passcode if using

--- a/pjlink.js
+++ b/pjlink.js
@@ -626,9 +626,9 @@ class PJInstance extends InstanceBase {
 			{
 				type: 'textinput',
 				id: 'host',
-				label: 'Target IP or Hostname',
+				label: 'Target IP',
 				width: 6,
-				regex: /^[a-zA-Z0-9.-]+$/,
+				regex: Regex.IP,
 			},
 			{
 				type: 'textinput',

--- a/pjlink.js
+++ b/pjlink.js
@@ -626,9 +626,9 @@ class PJInstance extends InstanceBase {
 			{
 				type: 'textinput',
 				id: 'host',
-				label: 'Target IP',
+				label: 'Target IP or Hostname',
 				width: 6,
-				regex: Regex.IP,
+				regex: /^[a-zA-Z0-9.-]+$/,
 			},
 			{
 				type: 'textinput',


### PR DESCRIPTION
## Summary
Fixed issue where feedback dropdowns were not updating when projector reports dynamic input names, causing mismatched input options between actions and feedbacks.

## Changes
- Added `this.init_feedbacks()` call in poll function to reload feedbacks when input names are updated
